### PR TITLE
https://sagebionetworks.jira.com/browse/BRIDGE-2172 Don't notify if completed burst

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeActivityNotificationWorker</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <properties>
         <aws.version>1.10.56</aws.version>

--- a/src/main/java/org/sagebionetworks/bridge/notification/helper/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/helper/DynamoHelper.java
@@ -35,6 +35,7 @@ public class DynamoHelper {
     static final String KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_END = "notificationBlackoutDaysFromEnd";
     static final String KEY_NOTIFICATION_TIME = "notificationTime";
     static final String KEY_NOTIFICATION_TYPE = "notificationType";
+    static final String KEY_NUM_ACTIVITIES_TO_COMPLETE = "numActivitiesToCompleteBurst";
     static final String KEY_NUM_MISSED_DAYS_TO_NOTIFY = "numMissedDaysToNotify";
     static final String KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY = "numMissedConsecutiveDaysToNotify";
     static final String KEY_PREBURST_MESSAGES = "preburstMessagesByDataGroup";
@@ -95,6 +96,7 @@ public class DynamoHelper {
         workerConfig.setMissedLaterActivitiesMessagesByDataGroup(item.getMap(KEY_MISSED_LATER_MESSAGES));
         workerConfig.setNotificationBlackoutDaysFromStart(item.getInt(KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_START));
         workerConfig.setNotificationBlackoutDaysFromEnd(item.getInt(KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_END));
+        workerConfig.setNumActivitiesToCompleteBurst(item.getInt(KEY_NUM_ACTIVITIES_TO_COMPLETE));
         workerConfig.setNumMissedConsecutiveDaysToNotify(item.getInt(KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY));
         workerConfig.setNumMissedDaysToNotify(item.getInt(KEY_NUM_MISSED_DAYS_TO_NOTIFY));
         workerConfig.setPreburstMessagesByDataGroup(item.getMap(KEY_PREBURST_MESSAGES));

--- a/src/main/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessor.java
@@ -367,6 +367,7 @@ public class BridgeNotificationWorkerProcessor implements ThrowingConsumer<JsonN
         int daysMissed = 0;
         int consecutiveDaysMissed = 0;
         int numDays = 0;
+        int numActivitiesCompleted = 0;
         for (LocalDate d = burstStartDate; !d.isAfter(date); d = d.plusDays(1)) {
             ScheduledActivity daysActivity = activitiesByDate.get(d);
             if (daysActivity == null || daysActivity.getStatus() != ScheduleStatus.FINISHED) {
@@ -385,6 +386,13 @@ public class BridgeNotificationWorkerProcessor implements ThrowingConsumer<JsonN
                 }
             } else {
                 consecutiveDaysMissed = 0;
+                numActivitiesCompleted++;
+
+                if (numActivitiesCompleted >= workerConfig.getNumActivitiesToCompleteBurst()) {
+                    // Participant has completed requisite number of activities to complete the study burst. We won't
+                    // send a notification. No need to process any further.
+                    return null;
+                }
             }
 
             // Increment the day counter so we can determine early vs late.

--- a/src/main/java/org/sagebionetworks/bridge/notification/worker/WorkerConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/worker/WorkerConfig.java
@@ -18,6 +18,7 @@ public class WorkerConfig {
     private Map<String, String> missedLaterActivitiesMessagesByDataGroup = ImmutableMap.of();
     private int notificationBlackoutDaysFromStart;
     private int notificationBlackoutDaysFromEnd;
+    private int numActivitiesToCompleteBurst;
     private int numMissedConsecutiveDaysToNotify;
     private int numMissedDaysToNotify;
     private Map<String, String> preburstMessagesByDataGroup = ImmutableMap.of();
@@ -143,6 +144,16 @@ public class WorkerConfig {
     /** @see #getNotificationBlackoutDaysFromEnd */
     public void setNotificationBlackoutDaysFromEnd(int notificationBlackoutDaysFromEnd) {
         this.notificationBlackoutDaysFromEnd = notificationBlackoutDaysFromEnd;
+    }
+
+    /** The total number of activities the participant needs to complete the study burst. */
+    public int getNumActivitiesToCompleteBurst() {
+        return numActivitiesToCompleteBurst;
+    }
+
+    /** @see #getNumActivitiesToCompleteBurst */
+    public void setNumActivitiesToCompleteBurst(int numActivitiesToCompleteBurst) {
+        this.numActivitiesToCompleteBurst = numActivitiesToCompleteBurst;
     }
 
     /** Number of consecutive days of missed activities before we send a notification. */

--- a/src/test/java/org/sagebionetworks/bridge/notification/helper/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/helper/DynamoHelperTest.java
@@ -98,6 +98,7 @@ public class DynamoHelperTest {
                 .withMap(DynamoHelper.KEY_MISSED_LATER_MESSAGES, missedLaterMessagesMap)
                 .withInt(DynamoHelper.KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_START, 2)
                 .withInt(DynamoHelper.KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_END, 1)
+                .withInt(DynamoHelper.KEY_NUM_ACTIVITIES_TO_COMPLETE, 6)
                 .withInt(DynamoHelper.KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY, 3)
                 .withInt(DynamoHelper.KEY_NUM_MISSED_DAYS_TO_NOTIFY, 4)
                 .withMap(DynamoHelper.KEY_PREBURST_MESSAGES, preburstMessagesMap)
@@ -119,6 +120,7 @@ public class DynamoHelperTest {
         assertEquals(config.getMissedLaterActivitiesMessagesByDataGroup(), missedLaterMessagesMap);
         assertEquals(config.getNotificationBlackoutDaysFromStart(), 2);
         assertEquals(config.getNotificationBlackoutDaysFromEnd(), 1);
+        assertEquals(config.getNumActivitiesToCompleteBurst(), 6);
         assertEquals(config.getNumMissedConsecutiveDaysToNotify(), 3);
         assertEquals(config.getNumMissedDaysToNotify(), 4);
         assertEquals(config.getPreburstMessagesByDataGroup(), preburstMessagesMap);

--- a/src/test/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessorProcessAccountTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessorProcessAccountTest.java
@@ -156,7 +156,8 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
         config.setMissedEarlyActivitiesMessagesByDataGroup(missedEarlyMessageMap);
         config.setMissedLaterActivitiesMessagesByDataGroup(missedLateMessageMap);
         config.setNotificationBlackoutDaysFromStart(3);
-        config.setNotificationBlackoutDaysFromEnd(3);
+        config.setNotificationBlackoutDaysFromEnd(1);
+        config.setNumActivitiesToCompleteBurst(6);
         config.setNumMissedConsecutiveDaysToNotify(2);
         config.setNumMissedDaysToNotify(3);
         config.setPreburstMessagesByDataGroup(preburstMessageMap);
@@ -257,8 +258,8 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
 
     @Test
     public void blackoutTail() throws Exception {
-        // Last three days (6, 7, 8) are blackout days
-        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE.plusDays(6), ACCOUNT_SUMMARY);
+        // Last days (8) is a blackout days
+        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE.plusDays(8), ACCOUNT_SUMMARY);
         verifyNoNotification();
     }
 
@@ -285,6 +286,19 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
         activityList.get(1).setStatus(ScheduleStatus.FINISHED);
         activityList.get(2).setStatus(ScheduleStatus.FINISHED);
         processor.processAccountForDate(STUDY_ID, TEST_DATE, ACCOUNT_SUMMARY);
+        verifyNoNotification();
+    }
+
+    @Test
+    public void dontNotifyIfCompletedBurst() throws Exception {
+        // Participant did days 0-5, then missed day 6 and 7. Burst is only 6 activities, so don't notify.
+        activityList.get(0).setStatus(ScheduleStatus.FINISHED);
+        activityList.get(1).setStatus(ScheduleStatus.FINISHED);
+        activityList.get(2).setStatus(ScheduleStatus.FINISHED);
+        activityList.get(3).setStatus(ScheduleStatus.FINISHED);
+        activityList.get(4).setStatus(ScheduleStatus.FINISHED);
+        activityList.get(5).setStatus(ScheduleStatus.FINISHED);
+        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE.plusDays(7), ACCOUNT_SUMMARY);
         verifyNoNotification();
     }
 


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-2172

The study burst is 19 days long. However, we only need 10 activities for the study burst. This change allows you to configure a burst complete limit, after which we would no longer notify the user.

Testing done: Updated unit tests, integ tests.